### PR TITLE
Parse OpenVPN telnet interface messages

### DIFF
--- a/server/.swcrc
+++ b/server/.swcrc
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": "inline",
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "legacyDecorator": true,
+      "decoratorMetadata": true
+    },
+    "baseUrl": "./src"
+  },
+  "minify": false
+}

--- a/server/src/open_vpn/domain/client.entity.ts
+++ b/server/src/open_vpn/domain/client.entity.ts
@@ -1,0 +1,47 @@
+export interface ClientConstructorOptions {
+  kid: string;
+  cid: string;
+  userId: string;
+}
+
+export class Client {
+  public readonly kid: string;
+  public readonly cid: string;
+  public readonly userId: string;
+  public readonly connectedAt = new Date();
+  public bytesIn = 0;
+  public bytesOut = 0;
+  public address?: string;
+  public static clients: Array<Client> = [];
+
+  constructor(data: ClientConstructorOptions) {
+    this.kid = data.kid;
+    this.cid = data.cid;
+    this.userId = data.userId;
+    this.connectedAt = new Date();
+    Client.addClient(this);
+  }
+
+  private static addClient(client: Client): void {
+    Client.clients.push(client);
+  }
+
+  public static removeClientByCid(cid: string): void {
+    Client.clients = Client.clients.filter((client) => client.cid !== cid);
+  }
+
+  public static updateByteCount(cid: string, bytesIn: number, bytesOut: number): Client {
+    const client = Client.clients.find((client) => client.cid === cid);
+    if (!client) throw new Error(`Client with cid ${cid} not found`);
+    client.bytesIn = bytesIn;
+    client.bytesOut = bytesOut;
+    return client;
+  }
+
+  public static updateAddress(cid: string, address: string): Client {
+    const client = Client.clients.find((client) => client.cid === cid);
+    if (!client) throw new Error(`Client with cid ${cid} not found`);
+    client.address = address;
+    return client;
+  }
+}

--- a/server/src/open_vpn/domain/open_vpn.service.ts
+++ b/server/src/open_vpn/domain/open_vpn.service.ts
@@ -1,12 +1,20 @@
 import {ConfigService} from '@nestjs/config';
 import {Injectable, Logger} from '@nestjs/common';
 import {OnEvent, EventEmitter2} from '@nestjs/event-emitter';
-import {ProcessManager} from 'open_vpn/infrastructure';
+import {ProcessManager, TelnetManager} from 'open_vpn/infrastructure';
 import {OpenVpnConfig} from './open_vpn_config.entity';
 import {UpdateOpenVpnOptions} from './open_vpn.service.interface';
 import {PkiService} from 'server/domain';
 import {ApiGatewayConnected} from 'server/presentation/api.gateway.event';
-import {ServerReadyEvent} from 'open_vpn/infrastructure/telnet.message';
+import {
+  ServerReadyEvent,
+  ClientConnectMessage,
+  ClientDisconnectMessage,
+  ByteCountMessage,
+  ClientByteCountMessage,
+  ClientAddressMessage,
+} from 'open_vpn/infrastructure/telnet.message';
+import {Client} from './client.entity';
 
 @Injectable()
 export class OpenVpnService {
@@ -17,6 +25,7 @@ export class OpenVpnService {
     private readonly processManager: ProcessManager,
     private readonly pkiService: PkiService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly telnetManager: TelnetManager,
   ) {}
 
   /** Update the server configuration */
@@ -36,9 +45,39 @@ export class OpenVpnService {
   }
 
   @OnEvent(ApiGatewayConnected.eventName)
-  onApiConnection(): void {
+  private onApiConnection(): void {
     if (this.processManager.isRunning())
       this.eventEmitter.emit(ServerReadyEvent.eventName, new ServerReadyEvent());
+  }
+
+  @OnEvent(ClientConnectMessage.eventName)
+  private onClientConnect(event: ClientConnectMessage): void {
+    this.logger.log(`Client connected [cid: ${event.client.cid}, userId: ${event.client.userId}]`);
+    this.telnetManager.authorizeClient(event.client);
+  }
+
+  @OnEvent(ClientDisconnectMessage.eventName)
+  private onClientDisconnect(event: ClientDisconnectMessage): void {
+    this.logger.log(`Client disconnected [cid: ${event.cid}]`);
+    Client.removeClientByCid(event.cid);
+  }
+
+  @OnEvent(ByteCountMessage.eventName)
+  private onByteCount(event: ByteCountMessage): void {
+    this.logger.debug(`Received global byte count [in: ${event.bytesIn}, out: ${event.bytesOut}`);
+  }
+
+  @OnEvent(ClientByteCountMessage.eventName)
+  private onClientByteCount(event: ClientByteCountMessage): void {
+    this.logger.debug(
+      `Received client byte count [cid: ${event.cid}, in: ${event.bytesIn}, out: ${event.bytesOut}`,
+    );
+  }
+
+  @OnEvent(ClientAddressMessage.eventName)
+  private onClientAddress(event: ClientAddressMessage): void {
+    Client.updateAddress(event.cid, event.address);
+    this.logger.debug(`Address assigned to client [cid: ${event.cid}, address: ${event.address}`);
   }
 
   public stop(): void {

--- a/server/src/open_vpn/domain/open_vpn_config.entity.ts
+++ b/server/src/open_vpn/domain/open_vpn_config.entity.ts
@@ -63,7 +63,6 @@ export class OpenVpnConfig {
     configFile.push('<key>', this.key.trim(), '</key>');
     // CA certificate
     configFile.push('<ca>', this.ca.trim(), '</ca>');
-    configFile.push('verb 6');
     return configFile.join('\n');
   }
 }

--- a/server/src/open_vpn/infrastructure/process.manager.ts
+++ b/server/src/open_vpn/infrastructure/process.manager.ts
@@ -55,6 +55,8 @@ export class ProcessManager implements OnModuleDestroy {
         'unix',
         // Send telnet events for each connection
         '--management-up-down',
+        '--management-client-auth',
+        '--auth-user-pass-optional',
       ],
       {
         detached: false,

--- a/server/src/open_vpn/infrastructure/telenet.manager.test.ts
+++ b/server/src/open_vpn/infrastructure/telenet.manager.test.ts
@@ -1,0 +1,119 @@
+import {TelnetManager} from './telnet.manager';
+import {Test} from '@nestjs/testing';
+import {EventEmitter2} from '@nestjs/event-emitter';
+import {ShutdownService} from 'lifecycle';
+
+describe('TelnetManager', () => {
+  let telnetManager: TelnetManager;
+  let mockShutdownService: Partial<ShutdownService>;
+  let mockEventEmitter: Partial<EventEmitter2>;
+
+  beforeEach(async () => {
+    mockShutdownService = {
+      shutdown: jest.fn(),
+    };
+
+    mockEventEmitter = {
+      emit: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [TelnetManager, ShutdownService, EventEmitter2],
+    })
+      .overrideProvider(ShutdownService)
+      .useValue(mockShutdownService)
+      .overrideProvider(EventEmitter2)
+      .useValue(mockEventEmitter)
+      .compile();
+
+    telnetManager = moduleRef.get<TelnetManager>(TelnetManager);
+  });
+
+  describe('onData', () => {
+    it('should parse ByteCount messages in a single chunk', () => {
+      const message = '>BYTECOUNT:123,456\n';
+
+      telnetManager['onData'](Buffer.from(message));
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('bytecount', {
+        bytesIn: 123,
+        bytesOut: 456,
+      });
+    });
+
+    it('should parse client connection messages in multiple chunks', async () => {
+      const message1 = `>CLIENT:CONNECT,0,1
+      >CLIENT:ENV,n_clients=0
+      >CLIENT:ENV,password=
+      >CLIENT:ENV,untrusted_port=59580
+      >CLIENT:ENV,untrusted_ip=82.64.71.34
+      >CLIENT:ENV,common_name=client:6506ee77a70089e2e9d3b700
+      >CLIENT:ENV,username=
+      >CLIENT:ENV,IV_PLAT_VER=30_11_x86_google_goldfish_x86_sdk_gphone_x86_arm
+      >CLIENT:ENV,IV_SSO=openurl,webauth,crtext
+      >CLIENT:ENV,IV_GUI_VER=com.client_1.0
+      >CLIENT:ENV,IV_COMP_STUBv2=1
+      >CLIENT:ENV,IV_COMP_STUB=1
+      >CLIENT:ENV,IV_LZO_STUB=1
+      >CLIENT:ENV,IV_PROTO=22
+      >CLIENT:ENV,IV_CIPHERS=AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305
+      >CLIENT:ENV,IV_NCP=2
+      >CLIENT:ENV,IV_TCPNL=1
+      >CLIENT:ENV,IV_PLAT=android
+      >CLIENT:ENV,IV_VER=2.6_master
+      >CLIENT:ENV,tls_serial_hex_0=09:91:53:32:22:56:34:93:90:00
+      >CLIENT:ENV,tls_serial_0=45182071128322320076800
+      >CLIENT:ENV,tls_digest_sha256_0=8a:89:bd:e5:34:6a:af:26:d3:b4:c0:fb:86:0e:45:be:69:a1:4f:07:e9:f5:3d:d1:a8:8f:7f:bd:4c:0e:d9:03
+      >CLIENT:ENV,tls_digest_0=c2:ee:8c:4b:f6:89:78:a2:13:74:15:43:7b:fa:21:2c:e4:96:ba:1f
+      `;
+
+      const message2 = `>CLIENT:ENV,tls_id_0=CN=client:6506ee77a70089e2e9d3b700, C=FR, ST=Paris, L=Paris, O=Prowire, OU=Prowire Certificate Authority
+      >CLIENT:ENV,X509_0_OU=Prowire Certificate Authority
+      >CLIENT:ENV,X509_0_O=Prowire
+      >CLIENT:ENV,X509_0_L=Paris
+      >CLIENT:ENV,X509_0_ST=Paris
+      >CLIENT:ENV,X509_0_C=FR
+      >CLIENT:ENV,X509_0_CN=client:6506ee77a70089e2e9d3b700
+      >CLIENT:ENV,tls_serial_hex_1=37:59:d6:c8:02:5e:1e:07:61:81:89:c5:b9:70:67:fd:c6:e7:f8:04
+      >CLIENT:ENV,tls_serial_1=315997968806790321126228663082402013795515365380
+      >CLIENT:ENV,tls_digest_sha256_1=a2:4d:f0:21:46:75:84:69:60:8a:28:14:5b:5b:64:03:03:8e:e3:9c:30:9e:83:36:2e:9e:b2:f1:78:8d:b7:cd
+      >CLIENT:ENV,tls_digest_1=e9:81:48:e4:6c:45:63:11:44:ef:36:54:dd:80:1f:10:04:77:6f:69
+      >CLIENT:ENV,tls_id_1=C=FR, ST=Ile de France, L=Paris, O=Prowire, OU=Prowire Certificate Authority, CN=Prowire Root Certificate Authority, emailAddress=contact@prowire.io
+      >CLIENT:ENV,X509_1_emailAddress=contact@prowire.io
+      >CLIENT:ENV,X509_1_CN=Prowire Root Certificate Authority
+      >CLIENT:ENV,X509_1_OU=Prowire Certificate Authority
+      >CLIENT:ENV,X509_1_O=Prowire
+      >CLIENT:ENV,X509_1_L=Paris
+      >CLIENT:ENV,X509_1_ST=Ile de France
+      >CLIENT:ENV,X509_1_C=FR
+      >CLIENT:ENV,remote_port_1=1194
+      >CLIENT:ENV,local_port_1=1194
+      >CLIENT:ENV,proto_1=udp
+      >CLIENT:ENV,daemon_pid=22
+      >CLIENT:ENV,daemon_start_time=1694958055
+      >CLIENT:ENV,daemon_log_redirect=0
+      >CLIENT:ENV,daemon=0
+      >CLIENT:ENV,verb=1
+      >CLIENT:ENV,config=/tmp/prowire--11-PuPNWV7zH1xK-.ovpn
+      >CLIENT:ENV,ifconfig_local=10.8.0.1
+      >CLIENT:ENV,ifconfig_netmask=255.255.255.0
+      >CLIENT:ENV,script_context=init
+      >CLIENT:ENV,tun_mtu=1500
+      >CLIENT:ENV,dev=tun0
+      >CLIENT:ENV,dev_type=tun
+      >CLIENT:ENV,redirect_gateway=0
+      >CLIENT:ENV,END
+      `;
+
+      await telnetManager['onData'](Buffer.from(message1));
+      await telnetManager['onData'](Buffer.from(message2));
+
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith('client-connect', {
+        type: 'CONNECT',
+        cid: '0',
+        kid: '1',
+        userId: '6506ee77a70089e2e9d3b700',
+      });
+    });
+  });
+});

--- a/server/src/open_vpn/infrastructure/telenet.manager.test.ts
+++ b/server/src/open_vpn/infrastructure/telenet.manager.test.ts
@@ -2,6 +2,7 @@ import {TelnetManager} from './telnet.manager';
 import {Test} from '@nestjs/testing';
 import {EventEmitter2} from '@nestjs/event-emitter';
 import {ShutdownService} from 'lifecycle';
+import {Client} from 'open_vpn/domain/client.entity';
 
 describe('TelnetManager', () => {
   let telnetManager: TelnetManager;
@@ -110,9 +111,7 @@ describe('TelnetManager', () => {
 
       expect(mockEventEmitter.emit).toHaveBeenCalledWith('client-connect', {
         type: 'CONNECT',
-        cid: '0',
-        kid: '1',
-        userId: '6506ee77a70089e2e9d3b700',
+        client: new Client({cid: '0', kid: '1', userId: '6506ee77a70089e2e9d3b700'}),
       });
     });
   });

--- a/server/src/open_vpn/infrastructure/telnet.message.ts
+++ b/server/src/open_vpn/infrastructure/telnet.message.ts
@@ -1,3 +1,5 @@
+import {Client} from 'open_vpn/domain/client.entity';
+
 export class ServerReadyEvent {
   public static readonly eventName = 'server-ready';
 }
@@ -7,22 +9,22 @@ export class ServerStopEvent {
 }
 
 export abstract class TelnetMessage {
-  public static readonly regex: RegExp;
+  public static readonly startRegex: RegExp;
+  public static readonly endRegex?: RegExp;
   public static readonly eventName: string;
 
-  public static validate(message: string): boolean {
-    return this.regex.test(message);
+  public static findStart(message: string): boolean {
+    return this.startRegex.test(message);
   }
 
-  protected match(message: string): RegExpExecArray {
-    const match = (<typeof TelnetMessage>this.constructor).regex.exec(message);
-    if (!match) throw new Error('Invalid message received');
-    return match;
+  public static findEnd(message: string): boolean {
+    if (!this.endRegex) return true;
+    return this.endRegex.test(message);
   }
 }
 
 export class ByteCountMessage extends TelnetMessage {
-  public static readonly regex = /BYTECOUNT:(\d+),(\d+)/;
+  public static readonly startRegex = />BYTECOUNT:(\d+),(\d+)/;
   public static readonly eventName = 'bytecount';
 
   public readonly bytesIn: number;
@@ -30,10 +32,90 @@ export class ByteCountMessage extends TelnetMessage {
 
   constructor(message: string) {
     super();
-    const match = this.match(message);
+    const match = ByteCountMessage.startRegex.exec(message);
+    if (!match) throw new Error('Cloud not find ByteCount information in message');
     this.bytesIn = parseInt(match[1], 10);
     this.bytesOut = parseInt(match[2], 10);
   }
 }
 
-export const messages = [ByteCountMessage];
+export class ClientByteCountMessage extends TelnetMessage {
+  public static readonly startRegex = />BYTECOUNT_CLI:(\d+),(\d+),(\d+)/;
+  public static readonly eventName = 'bytecount-cli';
+
+  public readonly cid: string;
+  public readonly bytesIn: number;
+  public readonly bytesOut: number;
+
+  constructor(message: string) {
+    super();
+    const match = ClientByteCountMessage.startRegex.exec(message);
+    if (!match) throw new Error('Cloud not find ByteCount information in message');
+    this.cid = match[1];
+    this.bytesIn = parseInt(match[2], 10);
+    this.bytesOut = parseInt(match[3], 10);
+  }
+}
+
+export class ClientConnectMessage extends TelnetMessage {
+  public static readonly startRegex = />CLIENT:(CONNECT|REAUTH),(\d+),(\d+)/;
+  public static readonly endRegex = />CLIENT:ENV,END/;
+  public static readonly eventName = 'client-connect';
+  public static readonly userIdRegex = />CLIENT:ENV,common_name=client:([a-zA-Z0-9]+)/;
+
+  public readonly client: Client;
+  public readonly type: 'CONNECT' | 'REAUTH';
+
+  constructor(message: string) {
+    super();
+    const headerMatch = ClientConnectMessage.startRegex.exec(message);
+    if (!headerMatch) throw new Error('Could not find header in message');
+    this.type = headerMatch[1] === 'CONNECT' ? 'CONNECT' : 'REAUTH';
+    const cid = headerMatch[2];
+    const kid = headerMatch[3];
+    const userIdMatch = ClientConnectMessage.userIdRegex.exec(message);
+    if (!userIdMatch) throw new Error('Could not find userId in message');
+    const userId = userIdMatch[1];
+    this.client = new Client({kid, cid, userId});
+  }
+}
+
+export class ClientDisconnectMessage extends TelnetMessage {
+  public static readonly startRegex = />CLIENT:DISCONNECT,(\d+)/;
+  public static readonly endRegex = />CLIENT:ENV,END/;
+  public static readonly eventName = 'client-disconnect';
+
+  public readonly cid: string;
+
+  constructor(message: string) {
+    super();
+    const match = ClientDisconnectMessage.startRegex.exec(message);
+    if (!match) throw new Error('Could not parse message');
+    this.cid = match[1];
+  }
+}
+
+export class ClientAddressMessage extends TelnetMessage {
+  public static readonly startRegex = />CLIENT:ADDRESS,(\d+),([0-9a-f:.]+),1/;
+  public static readonly endRegex = />CLIENT:ENV,END/;
+  public static readonly eventName = 'client-address';
+
+  public readonly cid: string;
+  public readonly address: string;
+
+  constructor(message: string) {
+    super();
+    const match = ClientAddressMessage.startRegex.exec(message);
+    if (!match) throw new Error('Could not parse message');
+    this.cid = match[1];
+    this.address = match[2];
+  }
+}
+
+export const messages = [
+  ByteCountMessage,
+  ClientByteCountMessage,
+  ClientConnectMessage,
+  ClientDisconnectMessage,
+  ClientAddressMessage,
+];

--- a/server/src/server/presentation/api.gateway.event.ts
+++ b/server/src/server/presentation/api.gateway.event.ts
@@ -1,3 +1,3 @@
 export class ApiGatewayConnected {
-  public static eventName: 'api-gateway-connected';
+  public static readonly eventName: 'api-gateway-connected';
 }


### PR DESCRIPTION
Added some parsing in the OpenVPN telnet communication channel.
- When a user connects
- When a user disconnects
- When an address is assigned to a user
- When we get global byte count
- When we get user specific byte count

For now this is all gathered and stored in memory locally

closes PRO-10