### PR TITLE
Increase test timeout with client

### DIFF
--- a/client/src/ui/components/Button/Button.test.tsx
+++ b/client/src/ui/components/Button/Button.test.tsx
@@ -11,9 +11,7 @@ describe('Button', () => {
   });
 
   it('should display given text', async () => {
-    console.log('A');
     render(<Button text={text} />);
-    console.log('B');
     await screen.findByText(text);
   });
 

--- a/client/src/ui/components/Button/Button.test.tsx
+++ b/client/src/ui/components/Button/Button.test.tsx
@@ -11,7 +11,9 @@ describe('Button', () => {
   });
 
   it('should display given text', async () => {
+    console.log('A');
     render(<Button text={text} />);
+    console.log('B');
     await screen.findByText(text);
   });
 

--- a/management/.swcrc
+++ b/management/.swcrc
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "sourceMaps": "inline",
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "dynamicImport": true
+    },
+    "baseUrl": "./src"
+  },
+  "minify": false
+}

--- a/management/jest.config.js
+++ b/management/jest.config.js
@@ -13,5 +13,6 @@ module.exports = {
   transform: {
     "^.+\\.(t|j)sx?$": ["@swc/jest"],
     "^.+\\.svg$": "jest-transform-stub"
-  }
+  },
+  testTimeout: 10_000,
 };


### PR DESCRIPTION
First load of the client can be very slow and often goes over the 5 seconds before the caching is done