### PR TITLE
[Server] Fix flaky test on OpenVPN manager

### DIFF
--- a/server/src/openVpn/infrastructure/telenet.manager.test.ts
+++ b/server/src/openVpn/infrastructure/telenet.manager.test.ts
@@ -111,7 +111,10 @@ describe('TelnetManager', () => {
 
       expect(mockEventEmitter.emit).toHaveBeenCalledWith('client-connect', {
         type: 'CONNECT',
-        client: new Client({cid: '0', kid: '1', userId: '6506ee77a70089e2e9d3b700'}),
+        client: {
+          ...new Client({cid: '0', kid: '1', userId: '6506ee77a70089e2e9d3b700'}),
+          connectedAt: expect.any(Date),
+        },
       });
     });
   });


### PR DESCRIPTION
There is a race condition here where if the evaluation happens at least 1ms after the event was emitted, we get a test failure.