### PR TITLE
[CI] Cancel workflows in PR if a new commit is added during execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:  
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,16 @@ name: Continuous integration
 on:
   # Run on every pull request targeting main
   pull_request:
-    branches:  
+    branches:
       - main
   # Run on every push to main
   push:
-    branches:  
+    branches:
       - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 
 jobs:
   build:
@@ -27,7 +26,7 @@ jobs:
         run: npm ci --workspaces
       - name: Build
         run: npm run build --workspaces
-  
+
   build_docker:
     name: Build containers
     runs-on: ubuntu-latest
@@ -35,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build containers
         run: docker compose build
-  
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This avoids waisting resources when commits are added shortly after another one in a PR.